### PR TITLE
Possibility to define rules based on parent content Ids

### DIFF
--- a/BackofficeTweaking/App_Code/Handlers/RulesHandler.cs
+++ b/BackofficeTweaking/App_Code/Handlers/RulesHandler.cs
@@ -75,7 +75,7 @@ namespace BackofficeTweaking.Handlers
                                 r.Enabled == true
                                 && (string.IsNullOrWhiteSpace(r.ContentTypes) || r.ContentTypes.ToDelimitedList().InvariantContains(content.ContentTypeAlias))
                                 && (string.IsNullOrWhiteSpace(r.ContentIds) || r.ContentIds.ToDelimitedList().InvariantContains(content.Id.ToString()))
-                                );
+                                && (string.IsNullOrWhiteSpace(r.ParentContentIds) || r.ParentContentIds.ToDelimitedList().InvariantContains(content.ParentId.ToString())));
 
                             if (rules.Count() < 1)
                             {

--- a/BackofficeTweaking/App_Code/Helpers/ConfigFileHelper.cs
+++ b/BackofficeTweaking/App_Code/Helpers/ConfigFileHelper.cs
@@ -199,6 +199,7 @@ namespace BackofficeTweaking.Helpers
                                     UserTypes = rule.Attribute("UserTypes").Value,
                                     Users = rule.Attribute("Users").Value,
                                     ContentIds = rule.Attributes().Any(a => a.Name.ToString().InvariantEquals("ContentIds")) ? rule.Attribute("ContentIds").Value : string.Empty,
+                                    ParentContentIds = rule.Attributes().Any(a => a.Name.ToString().InvariantEquals("ParentContentIds")) ? rule.Attribute("ParentContentIds").Value : string.Empty,
                                     ContentTypes = rule.Attribute("ContentTypes").Value,
                                     Description = rule.Attribute("Description").Value
                                 };

--- a/BackofficeTweaking/App_Plugins/Dashboard/backofficetweaking.dashboard.controller.js
+++ b/BackofficeTweaking/App_Plugins/Dashboard/backofficetweaking.dashboard.controller.js
@@ -23,6 +23,7 @@
                 { "title": "Users", "alias": "Users", "type": "textarea", "props": {} },
                 { "title": "User Types", "alias": "UserTypes", "type": "textarea", "props": {} },
                 { "title": "Content Ids", "alias": "ContentIds", "type": "textarea", "props": {} },
+                { "title": "Parent content Ids", "alias": "ParentContentIds", "type": "textarea", "props": {} },
                 { "title": "Content Types", "alias": "ContentTypes", "type": "textarea", "props": {} },
                 { "title": "Description", "alias": "Description", "type": "textarea", "props": {} }
             ]

--- a/BackofficeTweaking/Models/Rule.cs
+++ b/BackofficeTweaking/Models/Rule.cs
@@ -13,6 +13,7 @@ namespace BackofficeTweaking.Models
         public string UserTypes { get; set; }
         public string Users { get; set; }
         public string ContentIds { get; set; }
+        public string ParentContentIds { get; set; }
         public string ContentTypes { get; set; }
         public string Description { get; set; }
     }


### PR DESCRIPTION
A simple PR to enable setting rules based on direct parent content ids. I also wanted to add rules for all ancestors and parent/ancestor content types, however UmbracoContext is inacessible in RulesHandler and therefore getting to more parent info would be tricky.
